### PR TITLE
Xsltproc addition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+PKGBUILD -crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.downloads
+/.logs
+/.support
+/msys32
+/msys64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,7 +15,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-glew"
          "${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-wxPython"
-         "${MINGW_PACKAGE_PREFIX}-wxWidgets")
+         "${MINGW_PACKAGE_PREFIX}-wxWidgets"
+         "${MINGW_PACKAGE_PREFIX}-libxslt")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-doxygen"
              "${MINGW_PACKAGE_PREFIX}-gcc"

--- a/copydlls.sh
+++ b/copydlls.sh
@@ -155,7 +155,11 @@ copystuff() {
         "libintl*.dll" \
         "libtiff*.dll" \
         "liblzma*.dll" \
-        "libpython*.dll" )
+        "libpython*.dll" \
+        "libxml*.dll" \
+        "libxslt*.dll" \
+        "libexslt*.dll" \
+        "xsltproc.exe" )
 
     #echo Copying kicad binaries and stuff...
     #cp -r $MSYSDIR/bin/* $TARGETDIR/bin


### PR DESCRIPTION
Add xsltproc to the packaging as its needed to use the BOM and netlisting plugins. Windows doesn't really have a reliable xslt processor otherwise.

Also add a gitignore to ignore the working directories and a gitattributes to prevent CRLF on the PKGBUILD file because pacman is in the 1980s and complains about them.
