### PR TITLE
Add curl and ssl certificate to packaging.

### DIFF
--- a/KiCad-Winbuilder.cmake
+++ b/KiCad-Winbuilder.cmake
@@ -91,11 +91,11 @@ endif()
 set( TOOLCHAIN_PACKAGES "" )
 
 if( i686 )
-    set( TOOLCHAIN_PACKAGES "${TOOLCHAIN_PACKAGES} mingw-w64-i686-toolchain mingw-w64-i686-boost mingw-w64-i686-cairo mingw-w64-i686-glew mingw-w64-i686-openssl mingw-w64-i686-wxPython mingw-w64-i686-wxWidgets mingw-w64-i686-cmake mingw-w64-i686-gcc mingw-w64-i686-python2 mingw-w64-i686-pkg-config mingw-w64-i686-swig mingw-w64-i686-libxslt bzr git doxygen" )
+    set( TOOLCHAIN_PACKAGES "${TOOLCHAIN_PACKAGES} mingw-w64-i686-toolchain mingw-w64-i686-boost mingw-w64-i686-cairo mingw-w64-i686-curl mingw-w64-i686-glew mingw-w64-i686-openssl mingw-w64-i686-wxPython mingw-w64-i686-wxWidgets mingw-w64-i686-cmake mingw-w64-i686-gcc mingw-w64-i686-python2 mingw-w64-i686-pkg-config mingw-w64-i686-swig mingw-w64-i686-libxslt bzr git doxygen" )
 endif()
 
 if( x86_64 )
-    set( TOOLCHAIN_PACKAGES "${TOOLCHAIN_PACKAGES} mingw-w64-x86_64-toolchain mingw-w64-x86_64-boost mingw-w64-x86_64-cairo mingw-w64-x86_64-glew mingw-w64-x86_64-openssl mingw-w64-x86_64-wxPython mingw-w64-x86_64-wxWidgets mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc mingw-w64-x86_64-python2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-swig mingw-w64-x86_64-libxslt bzr git doxygen" )
+    set( TOOLCHAIN_PACKAGES "${TOOLCHAIN_PACKAGES} mingw-w64-x86_64-toolchain mingw-w64-x86_64-boost mingw-w64-x86_64-cairo mingw-w64-x86_64-curl mingw-w64-x86_64-glew mingw-w64-x86_64-openssl mingw-w64-x86_64-wxPython mingw-w64-x86_64-wxWidgets mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc mingw-w64-x86_64-python2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-swig mingw-w64-x86_64-libxslt bzr git doxygen" )
 endif()
 
 # Download and install an msys MinGW i686 package

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,6 +12,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-cairo"
+         "${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-glew"
          "${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-wxPython"

--- a/copydlls.sh
+++ b/copydlls.sh
@@ -159,7 +159,8 @@ copystuff() {
         "libxml*.dll" \
         "libxslt*.dll" \
         "libexslt*.dll" \
-        "xsltproc.exe" )
+        "xsltproc.exe"  \
+        "libcurl*.dll" )
 
     #echo Copying kicad binaries and stuff...
     #cp -r $MSYSDIR/bin/* $TARGETDIR/bin
@@ -181,6 +182,9 @@ copystuff() {
     rm -rf "${TARGETDIR}/lib/python2.7/test"
     find "${TARGETDIR}/lib/python2.7/" -name "*.pyc" -type f -delete
     find "${TARGETDIR}/lib/python2.7/" -name "*.pyo" -type f -delete
+
+    echo Copying ssl/certs/ca-bundle.crt
+    cp "$MSYSDIR/ssl/certs/ca-bundle.crt" "$TARGETDIR/ssl/certs"
 
     echo Copying python.exe...
     cp $MSYSDIR/bin/python.exe $TARGETDIR/bin

--- a/nsis/install.nsi
+++ b/nsis/install.nsi
@@ -197,6 +197,8 @@ Section $(TITLE_SEC_MAIN) SEC01
   File /r "..\lib\*"
   SetOutPath "$INSTDIR\share\kicad\internat"
   File /nonfatal /r "..\share\kicad\internat\*"
+  SetOutPath "$INSTDIR\ssl\certs"
+  File "..\ssl\certs\ca-bundle.crt"
 SectionEnd
 
 Section $(TITLE_SEC_SCHLIB) SEC02


### PR DESCRIPTION
FYI Nick, test this yourself

the builder no longer works on my PC anymore with msys2 seg faulting in bash. No idea what broke it was working fine before. msys2 standalone works fine.
