### PR TITLE
Quick fix of"HOME_DIR" variable and small improvement of Readme

### DIFF
--- a/KiCad-Winbuilder.cmake
+++ b/KiCad-Winbuilder.cmake
@@ -267,7 +267,7 @@ if( NOT EXISTS "${CMAKE_SOURCE_DIR}/${MSYS2}/msys2.ini" )
     download_msys2mingw_base_package( ${MSYS2_PACKAGE} ${MSYS2_MD5} )
 
 endif()
-file( GLOB HOME_DIR "${CMAKE_SOURCE_DIR}/${MSYS2}/home/*" )
+set(HOME_DIR "${CMAKE_SOURCE_DIR}/${MSYS2}/home/$ENV{USERNAME}" )
 
 macro( execute_msys2_bash CMD LOG )
     message( STATUS "Running ${CMD}" )
@@ -385,4 +385,3 @@ if( EXISTS "${KICAD_PACKAGE_SOURCE_DIR}/pkg/mingw-w64-x86_64-kicad-git/mingw64" 
                          --makensis=${NSIS_MAKE_COMMAND}"
                          "${LOG_DIR}/copydlls_mingw64" )
 endif()
-

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,19 @@
-﻿KiCad-Winbuilder provides the means to build up-to-date KiCad binaries
+# KiCad-Winbuilder
+KiCad-Winbuilder provides the means to build up-to-date KiCad binaries.
 
-Instructions:
-=========================================
-
+## Usage
+Using KiCad-Winbuilder is pretty straight forward:
 1. Download (and install) CMake from here: https://cmake.org/download/
-2. Git clone this repository to a location on your machine.
+2. Git clone this repository to a location on your machine
 3. Run make_all.bat from the freshly cloned git repository
 
+KiCad-Winbuilder will utilize approximately 10 Gb while downloading and building the dependencies. Make sure you have enough remaining space on your hard drive.
+
+## Concept
+KiCad-Windbuilder is loose **sandboxed**. That way it will not affect your system.
 
 
-Possible issues (and workarounds):
-========================================
+## Issues (and workarounds)
 
 MSYS2 issue with Windows 10 TH2, doesn't allow proper fork behaviour.
 Newly released version of MSYS2 contains a fix.  However must be manually updated at this time (20160103).
@@ -34,3 +37,7 @@ Procedure:
 4. open /etc/passwd in text editor and remove spaces from the username and the home directory locations (columns 1 and 5 from memory.. but it should be obvious)
 5. save file and close
 6. rename user home directory to remove space character
+
+## TODO
+- [ ] Nothing to see
+- [ ] Nothing to see

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Using KiCad-Winbuilder is pretty straight forward:
 2. `git clone` this repository to a location on your machine
 3. Run `make_all.bat` from the freshly cloned git repository
 
-KiCad-Winbuilder may utilize up to 10 Gb while downloading and building the dependencies. Make sure you have enough remaining space on your hard drive.
+KiCad-Winbuilder may utilize up to 10 GB while downloading and building the dependencies. Make sure you have enough remaining space on your hard drive.
 Depending on your hardware, the first build can take several hours to finish. Following builds will be much quicker though.
 
 ## Issues (and workarounds)

--- a/readme.md
+++ b/readme.md
@@ -3,15 +3,12 @@ KiCad-Winbuilder provides the means to build up-to-date KiCad binaries.
 
 ## Usage
 Using KiCad-Winbuilder is pretty straight forward:
-1. Download (and install) CMake from here: https://cmake.org/download/
-2. Git clone this repository to a location on your machine
-3. Run make_all.bat from the freshly cloned git repository
+1. Download and install [CMake](https://cmake.org/ "CMake Homepage")
+2. `git clone` this repository to a location on your machine
+3. Run `make_all.bat` from the freshly cloned git repository
 
-KiCad-Winbuilder will utilize approximately 10 Gb while downloading and building the dependencies. Make sure you have enough remaining space on your hard drive.
-
-## Concept
-KiCad-Windbuilder is loose **sandboxed**. That way it will not affect your system.
-
+KiCad-Winbuilder may utilize up to 10 Gb while downloading and building the dependencies. Make sure you have enough remaining space on your hard drive.
+Depending on your hardware, the first build can take several hours to finish. Following builds will be much quicker though.
 
 ## Issues (and workarounds)
 
@@ -37,7 +34,3 @@ Procedure:
 4. open /etc/passwd in text editor and remove spaces from the username and the home directory locations (columns 1 and 5 from memory.. but it should be obvious)
 5. save file and close
 6. rename user home directory to remove space character
-
-## TODO
-- [ ] Nothing to see
-- [ ] Nothing to see


### PR DESCRIPTION
Hello,

the variable `HOME_DIR` should point to the current users home folder in the msys environment. When multiple user folders existed, the `HOME_DIR` variable incorrectly contained a list of all users, not just the one logged in. That caused the build to fail.
I fixed that by explicitly setting the variable depending on the currently logged in windows user.

Furthermore I made some minor tweaks to the Readme. In the next few days I wanted to extend the Readme a little more in the hope that it will be usefull for new users.