### PR TITLE
All PKGBUILD files checkout with LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-PKGBUILD -crlf
+PKGBUILD* -crlf
 *.nsi -crlf
 *.nsh -crlf


### PR DESCRIPTION
PKGBUILD files with CRLF characters cause errors during build.
Checking them out with LF endings solves that problem