### PR TITLE
Update nsis and add file associations

### DIFF
--- a/KiCad-Winbuilder.cmake
+++ b/KiCad-Winbuilder.cmake
@@ -244,15 +244,10 @@ endif()
 
 # ------------------------------------------------------------------------------
 
-set( NSIS_URL http://sourceforge.net/projects/nsis/files/NSIS%203%20Pre-release/3.0b3/nsis-3.0b3.zip/download )
-set( NSIS_MD5 474bbfe55b908929ddf0b1c01744eb98 )
-set( NSIS_FN nsis-3.0b3.zip )
-set( NSIS_MAKE_COMMAND "${SUPPORT_DIR}/nsis-3.0b3/Bin/makensis.exe" )
-
-#set( NSIS_URL http://sourceforge.net/projects/nsis/files/NSIS%202/2.50/nsis-2.50.zip/download )
-#set( NSIS_MD5 94194d1fd5d604f293e22ede4b960ad9 )
-#set( NSIS_FN nsis-2.50.zip )
-#set( NSIS_MAKE_COMMAND "${SUPPORT_DIR}/nsis-2.50/makensis.exe" )
+set( NSIS_URL https://sourceforge.net/projects/nsis/files/NSIS%203/3.03/nsis-3.03.zip/download )
+set( NSIS_MD5 d4919dc089ec256a7264e97ada299b64 )
+set( NSIS_FN nsis-3.03.zip )
+set( NSIS_MAKE_COMMAND "${SUPPORT_DIR}/nsis-3.03/Bin/makensis.exe" )
 
 if( NOT EXISTS "${NSIS_MAKE_COMMAND}" )
     download_and_install( "${NSIS_URL}" "${NSIS_MD5}" "${NSIS_FN}" "${SUPPORT_DIR}" )

--- a/nsis/English.nsh
+++ b/nsis/English.nsh
@@ -31,6 +31,7 @@ LangString TITLE_SEC_FPWIZ ${LANG_ENGLISH} "Footprint wizards"
 LangString TITLE_SEC_DEMOS ${LANG_ENGLISH} "Demonstration projects"
 LangString TITLE_SEC_DOCS ${LANG_ENGLISH} "Help files"
 LangString TITLE_SEC_ENV ${LANG_ENGLISH} "Environment variables"
+LangString TITLE_SEC_FILE_ASSOC ${LANG_ENGLISH} "File associations"
 
 ;Component option descriptions
 LangString DESC_SEC_MAIN ${LANG_ENGLISH} "Main application files."
@@ -48,6 +49,13 @@ LangString DESC_SEC_DOCS_JA ${LANG_ENGLISH} "$(LANGUAGE_NAME_JA) $(TITLE_SEC_DOC
 LangString DESC_SEC_DOCS_NL ${LANG_ENGLISH} "$(LANGUAGE_NAME_NL) $(TITLE_SEC_DOCS)"
 LangString DESC_SEC_DOCS_PL ${LANG_ENGLISH} "$(LANGUAGE_NAME_PL) $(TITLE_SEC_DOCS)"
 LangString DESC_SEC_ENV ${LANG_ENGLISH} "Sets KISYSMOD, KISYS3DMOD and KICAD_PTEMPLATES environment variables to default install paths."
+LangString DESC_SEC_FILE_ASSOC ${LANG_ENGLISH} "Creates file associations for KiCad related files"
+
+;File association descriptions (show in Windows Explorer)
+LangString FILE_DESC_KICAD_PCB ${LANG_ENGLISH} "KiCad Board"
+LangString FILE_DESC_SCH ${LANG_ENGLISH} "KiCad Schematic"
+LangString FILE_DESC_PRO ${LANG_ENGLISH} "KiCad Project"
+LangString FILE_DESC_KICAD_WKS ${LANG_ENGLISH} "KiCad Page Layout"
 
 ;General messages
 LangString FREECAD_PROMPT ${LANG_ENGLISH} "To edit or create 3D object models you need to install FreeCAD. \

--- a/nsis/German.nsh
+++ b/nsis/German.nsh
@@ -31,6 +31,7 @@ LangString TITLE_SEC_FPWIZ ${LANG_GERMAN} "Footprint Wizards"
 LangString TITLE_SEC_DEMOS ${LANG_GERMAN} "Demo Projekte"
 LangString TITLE_SEC_DOCS ${LANG_GERMAN} "Hilfedateien"
 LangString TITLE_SEC_ENV ${LANG_GERMAN} "Umgebungsvariablen"
+LangString TITLE_SEC_FILE_ASSOC ${LANG_GERMAN} "File associations"
 
 ;Component option descriptions
 LangString DESC_SEC_MAIN ${LANG_GERMAN} "Dateien für das Hauptprogramm."
@@ -48,6 +49,13 @@ LangString DESC_SEC_DOCS_JA ${LANG_GERMAN} "$(LANGUAGE_NAME_JA) $(TITLE_SEC_DOCS
 LangString DESC_SEC_DOCS_NL ${LANG_GERMAN} "$(LANGUAGE_NAME_NL) $(TITLE_SEC_DOCS)"
 LangString DESC_SEC_DOCS_PL ${LANG_GERMAN} "$(LANGUAGE_NAME_PL) $(TITLE_SEC_DOCS)"
 LangString DESC_SEC_ENV ${LANG_GERMAN} "Fügt die Umgebungsvariablen KISYSMOD, KISYS3DMOD und KICAD_PTEMPLATES zu den standardmäßigen Installationspfaden hinzu."
+LangString DESC_SEC_FILE_ASSOC ${LANG_GERMAN} "Creates file associations for KiCad related files"
+
+;File association descriptions (show in Windows Explorer)
+LangString FILE_DESC_KICAD_PCB ${LANG_GERMAN} "KiCad Board"
+LangString FILE_DESC_SCH ${LANG_GERMAN} "KiCad Schematic"
+LangString FILE_DESC_PRO ${LANG_GERMAN} "KiCad Project"
+LangString FILE_DESC_KICAD_WKS ${LANG_GERMAN} "KiCad Page Layout"
 
 ;General messages
 LangString FREECAD_PROMPT ${LANG_GERMAN} "Um 3D Objekte zu erstellen oder verändern zu können benötigen Sie das Programm FreeCAD. \

--- a/nsis/Greek.nsh
+++ b/nsis/Greek.nsh
@@ -31,6 +31,7 @@ LangString TITLE_SEC_FPWIZ ${LANG_GREEK} "Οδηγοί αποτυπωμάτων"
 LangString TITLE_SEC_DEMOS ${LANG_GREEK} "Έργα επίδειξης"
 LangString TITLE_SEC_DOCS ${LANG_GREEK} "Αρχεία βοήθειας"
 LangString TITLE_SEC_ENV ${LANG_GREEK} "Μεταβλητές περιβάλλοντος"
+LangString TITLE_SEC_FILE_ASSOC ${LANG_GREEK} "File associations"
 
 ;Component option descriptions
 LangString DESC_SEC_MAIN ${LANG_GREEK} "Αρχεία κύριας εφαρμογής."
@@ -48,6 +49,13 @@ LangString DESC_SEC_DOCS_JA ${LANG_GREEK} "$(LANGUAGE_NAME_JA) $(TITLE_SEC_DOCS)
 LangString DESC_SEC_DOCS_NL ${LANG_GREEK} "$(LANGUAGE_NAME_NL) $(TITLE_SEC_DOCS)"
 LangString DESC_SEC_DOCS_PL ${LANG_GREEK} "$(LANGUAGE_NAME_PL) $(TITLE_SEC_DOCS)"
 LangString DESC_SEC_ENV ${LANG_GREEK} "Θέτει τις μεταβλητές περιβάλλοντος KISYSMOD, KISYS3DMOD και KICAD_PTEMPLATES στις προκαθορισμένες διαδρομές εγκατάστασης."
+LangString DESC_SEC_FILE_ASSOC ${LANG_GREEK} "Creates file associations for KiCad related files"
+
+;File association descriptions (show in Windows Explorer)
+LangString FILE_DESC_KICAD_PCB ${LANG_GREEK} "KiCad Board"
+LangString FILE_DESC_SCH ${LANG_GREEK} "KiCad Schematic"
+LangString FILE_DESC_PRO ${LANG_GREEK} "KiCad Project"
+LangString FILE_DESC_KICAD_WKS ${LANG_GREEK} "KiCad Page Layout"
 
 ;General messages
 LangString FREECAD_PROMPT ${LANG_GREEK} "Για να επεξεργαστείτε ή να δημιουργήσετε μοντέλα 3Δ απαιτείται η εγκατάσταση του FreeCAD. \

--- a/nsis/Italian.nsh
+++ b/nsis/Italian.nsh
@@ -31,6 +31,7 @@ LangString TITLE_SEC_FPWIZ ${LANG_ITALIAN} "Assistenti per le impronte di circui
 LangString TITLE_SEC_DEMOS ${LANG_ITALIAN} "Progetti dimostrativi"
 LangString TITLE_SEC_DOCS ${LANG_ITALIAN} "File di aiuto"
 LangString TITLE_SEC_ENV ${LANG_ITALIAN} "Variabili ambiente"
+LangString TITLE_SEC_FILE_ASSOC ${LANG_ITALIAN} "File associations"
 
 ;Component option descriptions
 LangString DESC_SEC_MAIN ${LANG_ITALIAN} "File dell'applicazione principale."
@@ -48,6 +49,13 @@ LangString DESC_SEC_DOCS_JA ${LANG_ITALIAN} "$(LANGUAGE_NAME_JA) $(TITLE_SEC_DOC
 LangString DESC_SEC_DOCS_NL ${LANG_ITALIAN} "$(LANGUAGE_NAME_NL) $(TITLE_SEC_DOCS)"
 LangString DESC_SEC_DOCS_PL ${LANG_ITALIAN} "$(LANGUAGE_NAME_PL) $(TITLE_SEC_DOCS)"
 LangString DESC_SEC_ENV ${LANG_ITALIAN} "Imposta le variabili ambiente KISYSMOD, KISYS3DMOD e KICAD_PTEMPLATES ai percorsi di installazione predefiniti."
+LangString DESC_SEC_FILE_ASSOC ${LANG_ITALIAN} "Creates file associations for KiCad related files"
+
+;File association descriptions (show in Windows Explorer)
+LangString FILE_DESC_KICAD_PCB ${LANG_ITALIAN} "KiCad Board"
+LangString FILE_DESC_SCH ${LANG_ITALIAN} "KiCad Schematic"
+LangString FILE_DESC_PRO ${LANG_ITALIAN} "KiCad Project"
+LangString FILE_DESC_KICAD_WKS ${LANG_ITALIAN} "KiCad Page Layout"
 
 ;General messages
 LangString FREECAD_PROMPT ${LANG_ITALIAN} "Per modificare o creare modelli 3D è necessario installare FreeCAD. \

--- a/nsis/Spanish.nsh
+++ b/nsis/Spanish.nsh
@@ -31,6 +31,7 @@ LangString TITLE_SEC_FPWIZ ${LANG_SPANISH} "Asistentes de huellas"
 LangString TITLE_SEC_DEMOS ${LANG_SPANISH} "Proyectos de demostración"
 LangString TITLE_SEC_DOCS ${LANG_SPANISH} "Archivos de ayuda"
 LangString TITLE_SEC_ENV ${LANG_SPANISH} "Variables de entorno"
+LangString TITLE_SEC_FILE_ASSOC ${LANG_SPANISH} "File associations"
 
 ;Component option descriptions
 LangString DESC_SEC_MAIN ${LANG_SPANISH} "Archivos de la aplicación principal."
@@ -48,6 +49,13 @@ LangString DESC_SEC_DOCS_JA ${LANG_SPANISH} "$(LANGUAGE_NAME_JA) $(TITLE_SEC_DOC
 LangString DESC_SEC_DOCS_NL ${LANG_SPANISH} "$(LANGUAGE_NAME_NL) $(TITLE_SEC_DOCS)"
 LangString DESC_SEC_DOCS_PL ${LANG_SPANISH} "$(LANGUAGE_NAME_PL) $(TITLE_SEC_DOCS)"
 LangString DESC_SEC_ENV ${LANG_SPANISH} "Ajusta las variables de entorno KISYSMOD, KISYS3DMOD y KICAD_PTEMPLATES a las rutas por defecto."
+LangString DESC_SEC_FILE_ASSOC ${LANG_SPANISH} "Creates file associations for KiCad related files"
+
+;File association descriptions (show in Windows Explorer)
+LangString FILE_DESC_KICAD_PCB ${LANG_SPANISH} "KiCad Board"
+LangString FILE_DESC_SCH ${LANG_SPANISH} "KiCad Schematic"
+LangString FILE_DESC_PRO ${LANG_SPANISH} "KiCad Project"
+LangString FILE_DESC_KICAD_WKS ${LANG_SPANISH} "KiCad Page Layout"
 
 ;General messages
 LangString FREECAD_PROMPT ${LANG_SPANISH} "Para editar o crear modelos de objetos 3D es necesario instalar FreeCAD. \

--- a/nsis/install.nsi
+++ b/nsis/install.nsi
@@ -43,6 +43,9 @@
 
 !define ENV_HKLM 'HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"'
 
+!define REG_VALUE_NAME	"KiCad"
+!define SOFTWARE_CLASSES_ROOT_KEY 'HKLM'
+
 !define gflag ;Needed to use ifdef and such
 ;Define on command line //DPRODUCT_VERSION=42
 !ifndef PRODUCT_VERSION
@@ -151,6 +154,54 @@ VIAddVersionKey "FileVersion" "${PRODUCT_VERSION}"
   !insertmacro MUI_RESERVEFILE_LANGDLL
 
 ; MUI end ------
+
+;--------------------------------
+; File Association Helpers
+
+!macro _DeleteFileAssociationFunc EXT
+  ;be sure to only delete the specific kicad.extension entry
+  DeleteRegValue ${SOFTWARE_CLASSES_ROOT_KEY} "Software\Classes\.${EXT}\OpenWithProgids\" "${REG_VALUE_NAME}.${EXT}"
+  ;delete the entire kicad.extension key set
+  DeleteRegKey ${SOFTWARE_CLASSES_ROOT_KEY} "Software\Classes\${REG_VALUE_NAME}.${EXT}"
+!macroend
+
+!macro _CreateFileAssociationFunc
+  Exch $R0 ;ext
+  Exch
+  Exch $R1 ;exe
+  Exch
+  Exch 2
+  Exch $R2 ;desc
+  Exch 2
+  Exch 3
+  Exch $R3 ;ICON_RESOURCE_NAME
+  
+  ;global extension reference to program
+  WriteRegExpandStr ${SOFTWARE_CLASSES_ROOT_KEY} "Software\Classes\.$R0\OpenWithProgids\" "${REG_VALUE_NAME}.$R0" ""
+
+  ;program level extension entry
+  WriteRegExpandStr ${SOFTWARE_CLASSES_ROOT_KEY} "Software\Classes\${REG_VALUE_NAME}.$R0" "" "$R2"
+  WriteRegExpandStr ${SOFTWARE_CLASSES_ROOT_KEY} "Software\Classes\${REG_VALUE_NAME}.$R0\" "DefaultIcon" "$INSTDIR\bin\$R1,$R3"
+  WriteRegExpandStr ${SOFTWARE_CLASSES_ROOT_KEY} "Software\Classes\${REG_VALUE_NAME}.$R0\shell\open\command" "" '$INSTDIR\bin\$R1 "%1"'
+
+  Pop $R3
+  Pop $R2
+  Pop $R1
+  Pop $R0
+!macroend
+
+!macro CreateFileAssociationCall EXT EXE DESCRIPTION ICON_RESOURCE_NAME
+  Push `${ICON_RESOURCE_NAME}`
+  Push `${DESCRIPTION}`
+  Push `${EXE}`
+  Push `${EXT}`
+  ${CallArtificialFunction} _CreateFileAssociationFunc
+!macroend
+
+!define CreateFileAssociation `!insertmacro CreateFileAssociationCall`
+!define DeleteFileAssociation `!insertmacro _DeleteFileAssociationFunc`
+
+;--------------------------------
 
 Function .onInit
   ; Request that we get elevated rights to install so that we don't end up in
@@ -311,6 +362,15 @@ Section $(TITLE_SEC_ENV) SEC07
   SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
 SectionEnd
 
+Section $(TITLE_SEC_FILE_ASSOC) SEC08
+  ${CreateFileAssociation} "kicad_pcb" "pcbnew.exe" $(FILE_DESC_KICAD_PCB) "icon_pcbnew"
+  ${CreateFileAssociation} "sch" "eeschema.exe" $(FILE_DESC_SCH) "icon_eeschema"
+  ${CreateFileAssociation} "pro" "kicad.exe" $(FILE_DESC_PRO) "icon_kicad"
+  ${CreateFileAssociation} "kicad_wks" "pl_editor.exe" $(FILE_DESC_KICAD_WKS) "icon_pagelayout_editor"
+
+  WriteRegDWORD ${UNINST_ROOT} "${PRODUCT_UNINST_KEY}" "FileAssocInstalled" "1"
+SectionEnd
+
 Section -CreateShortcuts
   SetOutPath $INSTDIR
   WriteIniStr "$INSTDIR\HomePage.url"     "InternetShortcut" "URL" "${KICAD_MAIN_SITE}"
@@ -367,6 +427,7 @@ SectionEnd
   !insertmacro MUI_DESCRIPTION_TEXT ${SEC06_NL} $(DESC_SEC_DOCS_NL)
   !insertmacro MUI_DESCRIPTION_TEXT ${SEC06_PL} $(DESC_SEC_DOCS_PL)
   !insertmacro MUI_DESCRIPTION_TEXT ${SEC07} $(DESC_SEC_ENV)
+  !insertmacro MUI_DESCRIPTION_TEXT ${SEC08} $(DESC_SEC_FILE_ASSOC)
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 Function un.onInit
@@ -450,6 +511,18 @@ Section Uninstall
   DeleteRegValue ${ENV_HKLM} KISYSMOD
   DeleteRegValue ${ENV_HKLM} KICAD_SYMBOL_DIR
   SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  
+  ;remove file association only if it was installed
+  ClearErrors
+  ReadRegDWORD $0 ${UNINST_ROOT} "${PRODUCT_UNINST_KEY}" "FileAssocInstalled"
+  IfErrors FinishUninstall 0
+  
+  IntCmp $0 1 0 FinishUninstall FinishUninstall
+  
+  ;delete file associations
+  ${DeleteFileAssociation} "kicad_pcb"
+  ${DeleteFileAssociation} "sch"
+  ${DeleteFileAssociation} "pro"
   
   FinishUninstall:
   ;Note - application registry keys are stored in the users individual registry hive (HKCU\Software\kicad".

--- a/nsis/install.nsi
+++ b/nsis/install.nsi
@@ -523,6 +523,7 @@ Section Uninstall
   ${DeleteFileAssociation} "kicad_pcb"
   ${DeleteFileAssociation} "sch"
   ${DeleteFileAssociation} "pro"
+  ${DeleteFileAssociation} "kicad_wks"
   
   FinishUninstall:
   ;Note - application registry keys are stored in the users individual registry hive (HKCU\Software\kicad".


### PR DESCRIPTION
this adds file association for .pro files. So they will autoopen kicad ;)

I tried eeschema and pcbnew files as well but it appears they can't handle being passed files like that yet. kicad.exe works fine with pro files.

One thing is we need to copy a icon to the install folder, so not sure how to do that.