### PR TITLE
Add registration of friendly application names displayed in the open with dialog.

### DIFF
--- a/nsis/English.nsh
+++ b/nsis/English.nsh
@@ -57,6 +57,12 @@ LangString FILE_DESC_SCH ${LANG_ENGLISH} "KiCad Schematic"
 LangString FILE_DESC_PRO ${LANG_ENGLISH} "KiCad Project"
 LangString FILE_DESC_KICAD_WKS ${LANG_ENGLISH} "KiCad Page Layout"
 
+;Application Friendly Names
+LangString APP_FRIENDLY_KICAD ${LANG_ENGLISH} "KiCad"
+LangString APP_FRIENDLY_PCBNEW ${LANG_ENGLISH} "KiCad - Pcbnew"
+LangString APP_FRIENDLY_EESCHEMA ${LANG_ENGLISH} "KiCad - Eeschema"
+LangString APP_FRIENDLY_PLEDITOR ${LANG_ENGLISH} "KiCad - Page Layout Editor"
+
 ;General messages
 LangString FREECAD_PROMPT ${LANG_ENGLISH} "To edit or create 3D object models you need to install FreeCAD. \
 FreeCAD and user manual can be download free from the FreeCAD web page. Check this box to open the FreeCAD web page."

--- a/nsis/German.nsh
+++ b/nsis/German.nsh
@@ -57,6 +57,12 @@ LangString FILE_DESC_SCH ${LANG_GERMAN} "KiCad Schematic"
 LangString FILE_DESC_PRO ${LANG_GERMAN} "KiCad Project"
 LangString FILE_DESC_KICAD_WKS ${LANG_GERMAN} "KiCad Page Layout"
 
+;Application Friendly Names
+LangString APP_FRIENDLY_KICAD ${LANG_GERMAN} "KiCad"
+LangString APP_FRIENDLY_PCBNEW ${LANG_GERMAN} "KiCad - Pcbnew"
+LangString APP_FRIENDLY_EESCHEMA ${LANG_GERMAN} "KiCad - Eeschema"
+LangString APP_FRIENDLY_PLEDITOR ${LANG_GERMAN} "KiCad - Page Layout Editor"
+
 ;General messages
 LangString FREECAD_PROMPT ${LANG_GERMAN} "Um 3D Objekte zu erstellen oder verändern zu können benötigen Sie das Programm FreeCAD. \
 FreeCAD und das zugehörige Benutzerhandbuch können frei von der der Webdeite von FreeCAD Webseite geladen werden. Aktivieren Sie diese Checkbox um die FreeCAD Webseite zu öffnen."

--- a/nsis/Greek.nsh
+++ b/nsis/Greek.nsh
@@ -57,6 +57,12 @@ LangString FILE_DESC_SCH ${LANG_GREEK} "KiCad Schematic"
 LangString FILE_DESC_PRO ${LANG_GREEK} "KiCad Project"
 LangString FILE_DESC_KICAD_WKS ${LANG_GREEK} "KiCad Page Layout"
 
+;Application Friendly Names
+LangString APP_FRIENDLY_KICAD ${LANG_GREEK} "KiCad"
+LangString APP_FRIENDLY_PCBNEW ${LANG_GREEK} "KiCad - Pcbnew"
+LangString APP_FRIENDLY_EESCHEMA ${LANG_GREEK} "KiCad - Eeschema"
+LangString APP_FRIENDLY_PLEDITOR ${LANG_GREEK} "KiCad - Page Layout Editor"
+
 ;General messages
 LangString FREECAD_PROMPT ${LANG_GREEK} "Για να επεξεργαστείτε ή να δημιουργήσετε μοντέλα 3Δ απαιτείται η εγκατάσταση του FreeCAD. \
 Μπορείτε να κατεβάσετε το FreeCAD και τον οδηγό χρήσης του, δωρεάν από την ιστοσελίδα του FreeCAD. Κάντε τικ σε αυτό το κουτάκι για να ανοίξει η ιστοσελίδα του FreeCAD."

--- a/nsis/Italian.nsh
+++ b/nsis/Italian.nsh
@@ -57,6 +57,12 @@ LangString FILE_DESC_SCH ${LANG_ITALIAN} "KiCad Schematic"
 LangString FILE_DESC_PRO ${LANG_ITALIAN} "KiCad Project"
 LangString FILE_DESC_KICAD_WKS ${LANG_ITALIAN} "KiCad Page Layout"
 
+;Application Friendly Names
+LangString APP_FRIENDLY_KICAD ${LANG_ITALIAN} "KiCad"
+LangString APP_FRIENDLY_PCBNEW ${LANG_ITALIAN} "KiCad - Pcbnew"
+LangString APP_FRIENDLY_EESCHEMA ${LANG_ITALIAN} "KiCad - Eeschema"
+LangString APP_FRIENDLY_PLEDITOR ${LANG_ITALIAN} "KiCad - Page Layout Editor"
+
 ;General messages
 LangString FREECAD_PROMPT ${LANG_ITALIAN} "Per modificare o creare modelli 3D è necessario installare FreeCAD. \
 FreeCAD ed il suo manuale utente possono essere scaricati liberamente dalla pagina web di FreeCAD. Selezionare questa casella per aprire la pagina web di FreeCAD."

--- a/nsis/Spanish.nsh
+++ b/nsis/Spanish.nsh
@@ -57,6 +57,12 @@ LangString FILE_DESC_SCH ${LANG_SPANISH} "KiCad Schematic"
 LangString FILE_DESC_PRO ${LANG_SPANISH} "KiCad Project"
 LangString FILE_DESC_KICAD_WKS ${LANG_SPANISH} "KiCad Page Layout"
 
+;Application Friendly Names
+LangString APP_FRIENDLY_KICAD ${LANG_SPANISH} "KiCad"
+LangString APP_FRIENDLY_PCBNEW ${LANG_SPANISH} "KiCad - Pcbnew"
+LangString APP_FRIENDLY_EESCHEMA ${LANG_SPANISH} "KiCad - Eeschema"
+LangString APP_FRIENDLY_PLEDITOR ${LANG_SPANISH} "KiCad - Page Layout Editor"
+
 ;General messages
 LangString FREECAD_PROMPT ${LANG_SPANISH} "Para editar o crear modelos de objetos 3D es necesario instalar FreeCAD. \
 FreeCAD y su manual de usuario pueden descargarse desde la página web de FreeCAD. Seleccione esta opción para abrir la página web de FreeCAD."

--- a/nsis/install.nsi
+++ b/nsis/install.nsi
@@ -203,6 +203,29 @@ VIAddVersionKey "FileVersion" "${PRODUCT_VERSION}"
 
 ;--------------------------------
 
+!macro _RegisterApplicationFunc
+  Exch $R0 ;exe
+  Exch
+  Exch $R1 ;desc
+
+  ;global extension reference to program
+  WriteRegExpandStr ${SOFTWARE_CLASSES_ROOT_KEY} "Software\Classes\Applications\$R0\shell\open" "FriendlyAppName" "$R1"
+  WriteRegExpandStr ${SOFTWARE_CLASSES_ROOT_KEY} "Software\Classes\Applications\$R0\shell\open\command" "" '$INSTDIR\bin\$R0 "%1"'
+
+  Pop $R1
+  Pop $R0
+!macroend
+
+!macro RegisterApplicationCall EXE DESCRIPTION
+  Push `${DESCRIPTION}`
+  Push `${EXE}`
+  ${CallArtificialFunction} _RegisterApplicationFunc
+!macroend
+
+!define RegisterApplication `!insertmacro RegisterApplicationCall`
+
+;--------------------------------
+
 Function .onInit
   ; Request that we get elevated rights to install so that we don't end up in
   ; the virtual store
@@ -278,6 +301,11 @@ Section $(TITLE_SEC_MAIN) SEC01
   File /nonfatal /r "..\share\kicad\internat\*"
   SetOutPath "$INSTDIR\ssl\certs"
   File "..\ssl\certs\ca-bundle.crt"
+
+  ${RegisterApplication} "kicad.exe" $(APP_FRIENDLY_KICAD)
+  ${RegisterApplication} "pcbnew.exe" $(APP_FRIENDLY_PCBNEW)
+  ${RegisterApplication} "eeschema.exe" $(APP_FRIENDLY_EESCHEMA)
+  ${RegisterApplication} "pl_editor.exe" $(APP_FRIENDLY_PLEDITOR)
 SectionEnd
 
 Section $(TITLE_SEC_SCHLIB) SEC02


### PR DESCRIPTION

More fancy to add.
The Open With option in Windows will display the name of this registry key.

![Image](https://i.imgur.com/wavffqj.png)

Otherwise it only displays "pl_editor.exe" which is boring.

Also it gives it a default command syntax in case somebody tries to assign the programs to a different file type.