### PR TITLE
Add a fallback user directory

### DIFF
--- a/KiCad-Winbuilder.cmake
+++ b/KiCad-Winbuilder.cmake
@@ -313,6 +313,10 @@ endif()
 # KiCad pacman package source
 # Get the home directory
 file( GLOB HOME_DIR "${CMAKE_SOURCE_DIR}/${MSYS2}/home/*" )
+if ( "${HOME_DIR}" STREQUAL "" )
+    set( HOME_DIR "${CMAKE_SOURCE_DIR}/${MSYS2}/home/user" )
+    file( MAKE_DIRECTORY "${HOME_DIR}" )
+endif()
 set( KICAD_PACKAGE_SOURCE_DIR "${HOME_DIR}/MINGW-packages/mingw-w64-kicad-git/" )
 message( STATUS "HOME_DIR ${HOME_DIR}" )
 message( STATUS "KICAD_PACKAGE_SOURCE_DIR ${KICAD_PACKAGE_SOURCE_DIR}" )


### PR DESCRIPTION
For the first time I see the issue some people have been reported about
the user not showing up and the build fails.

It seems that depending on what type of windows user you have the setup
is initilized slightly different in msys2, so I will solve this with a
fallback user name of "user". The user name is not really important,
something just need to be defined.